### PR TITLE
fix DBusMenuExporterPrivate::addAction errors when updating "View" menu

### DIFF
--- a/spykeviewer/ui/main_window.py
+++ b/spykeviewer/ui/main_window.py
@@ -265,6 +265,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         if hasattr(self, 'menuView'):
             a = self.menuView.menuAction()
             self.mainMenu.removeAction(a)
+            self.menuView.clear()
         self.menuView = self.createPopupMenu()
         self.menuView.setTitle('&View')
         self.mainMenu.insertMenu(self.menuHelp.menuAction(), self.menuView)


### PR DESCRIPTION
Recent versions of Ubuntu give DBusMenuExporterPrivate::addAction errors when adding the same action multiple times.
