### PR TITLE
Catch AttributeError

### DIFF
--- a/spykeviewer/ui/plugin_editor_dock.py
+++ b/spykeviewer/ui/plugin_editor_dock.py
@@ -41,7 +41,7 @@ class SamplePlugin(analysis_plugin.AnalysisPlugin):
         self.thread_manager = ThreadManager(self)
         try:
             self.rope_project = codeeditor.get_rope_project()
-        except IOError:  # Might happen when frozen
+        except (IOError, AttributeError):  # Might happen when frozen
             self.rope_project = None
 
         data_path = QDesktopServices.storageLocation(


### PR DESCRIPTION
Catch AttributeError to make it compatible with future version of spyderlib which may replace rope with jedi.
